### PR TITLE
Fixed  Cannot use empty string as a class name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -401,7 +401,7 @@ class dhcpd (
 
 
   ### Include custom class if $my_class is set
-  if $dhcpd::my_class {
+  if $dhcpd::my_class and $dhcpd::my_class != '' {
     include $dhcpd::my_class
   }
 


### PR DESCRIPTION
Evaluation Error: Error while evaluating a Function Call, Cannot use empty string as a class name

